### PR TITLE
Require internet connection.

### DIFF
--- a/index.md
+++ b/index.md
@@ -123,7 +123,7 @@ Matthias 1013
   <strong>Requirements:</strong> Participants must bring a laptop with a
   Mac, Linux, or Windows operating system (not a tablet, Chromebook, etc.) that they have administrative privileges
   on. They should have a few specific software packages installed (listed
-  <a href="#setup">below</a>). They are also required to abide by
+  <a href="#setup">below</a>), and should be able to connect their laptops to the internet during the workshop. They are also required to abide by
   {% if page.carpentry == "swc" %}
   Software Carpentry's
   {% elsif page.carpentry == "dc" %}


### PR DESCRIPTION
Inform participants that they require to connect to internet during the workshop. Participants require internet for at lease two things:
1. Write collaborative documents (etherpad or similar)
2. Install R packages